### PR TITLE
Fix San Juan's page title.

### DIFF
--- a/src/htdocs/monitoring/observatories/sanjuan/index.php
+++ b/src/htdocs/monitoring/observatories/sanjuan/index.php
@@ -1,6 +1,6 @@
 <?php
 if (!isset($TEMPLATE)) {
-  $TITLE = 'Newport (NEW)';
+  $TITLE = 'San Juan (SJG)';
   $HEAD = '<link rel="stylesheet" href="tablist/tablist.css"/>
           <meta name="viewport" content="width=device-width">';
   $NAVIGATION = true;


### PR DESCRIPTION
Fixes usgs/geomag-website#141
Fixes #141 San Juan is labeled as Newport