### PR TITLE
Open index page by default when running grunt.

### DIFF
--- a/gruntconfig/connect.js
+++ b/gruntconfig/connect.js
@@ -58,7 +58,7 @@ var connect = {
       ],
       livereload: config.liveReloadPort,
       middleware: addMiddleware,
-      open: true,
+      open: 'http://localhost:' + config.srcPort + '/index.php',
       port: config.srcPort
     }
   },


### PR DESCRIPTION
Fixes #119 Auto-open index in grunt connect